### PR TITLE
Fix incorrect object on 08_generate_embeddings_titan.ipynb

### DIFF
--- a/12_bedrock/08_generate_embeddings_titan.ipynb
+++ b/12_bedrock/08_generate_embeddings_titan.ipynb
@@ -176,7 +176,7 @@
     "# We will be using the Titan Embeddings Model to generate our Embeddings.\n",
     "\n",
     "def get_embedding(body, modelId, accept, contentType):\n",
-    "    response = bedrock.invoke_model(\n",
+    "    response = bedrock_runtime.invoke_model(\n",
     "        body=body, \n",
     "        modelId=modelId, \n",
     "        accept=accept, \n",


### PR DESCRIPTION
bedrock object does not have method called invoke_model bedrock_runtime object does